### PR TITLE
Configured enable to use dynamic oauth introspection url parameter

### DIFF
--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/services/ValidatorKey.java
@@ -142,6 +142,7 @@ public class ValidatorKey {
         private final String validTokenType;
         private final String clientId;
         private final String clientSecret;
+        private final String introspectionEndpointParam;
 
         @SuppressWarnings("checkstyle:parameternumber")
         public IntrospectionValidatorKey(String validIssuerUri,
@@ -162,7 +163,8 @@ public class ValidatorKey {
                                   String clientId,
                                   String clientSecret,
                                   int connectTimeout,
-                                  int readTimeout) {
+                                  int readTimeout,
+                                  String introspectionEndpointParam) {
 
             super(validIssuerUri, audience, customClaimCheck, usernameClaim, fallbackUsernameClaim, fallbackUsernamePrefix, sslTruststore, sslStorePassword, sslStoreType, sslRandom, hasHostnameVerifier, connectTimeout, readTimeout);
             this.introspectionEndpoint = introspectionEndpoint;
@@ -170,6 +172,7 @@ public class ValidatorKey {
             this.validTokenType = validTokenType;
             this.clientId = clientId;
             this.clientSecret = clientSecret;
+            this.introspectionEndpointParam = introspectionEndpointParam;
         }
 
         @Override
@@ -182,12 +185,13 @@ public class ValidatorKey {
                     Objects.equals(userInfoEndpoint, that.userInfoEndpoint) &&
                     Objects.equals(validTokenType, that.validTokenType) &&
                     Objects.equals(clientId, that.clientId) &&
-                    Objects.equals(clientSecret, that.clientSecret);
+                    Objects.equals(clientSecret, that.clientSecret) &&
+                    Objects.equals(introspectionEndpointParam, that.introspectionEndpointParam);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(super.hashCode(), introspectionEndpoint, userInfoEndpoint, validTokenType, clientId, clientSecret);
+            return Objects.hash(super.hashCode(), introspectionEndpoint, userInfoEndpoint, validTokenType, clientId, clientSecret, introspectionEndpointParam);
         }
     }
 }

--- a/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
+++ b/oauth-common/src/main/java/io/strimzi/kafka/oauth/validator/OAuthIntrospectionValidator.java
@@ -51,6 +51,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
     private final SSLSocketFactory socketFactory;
     private final HostnameVerifier hostnameVerifier;
     private final PrincipalExtractor principalExtractor;
+    private final String introspectionEndpointParam;
 
     private final int connectTimeoutSeconds;
     private final int readTimeoutSeconds;
@@ -70,6 +71,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
      * @param customClaimCheck The optional JSONPath filter query for additional custom attribute checking
      * @param connectTimeoutSeconds The maximum time to wait for connection to authorization server to be established (in seconds)
      * @param readTimeoutSeconds The maximum time to wait for response from authorization server after connection has been established and request sent (in seconds)
+     * @param introspectionEndpointParam The introspection endpoint url parameter at the authorization server
      */
     public OAuthIntrospectionValidator(String introspectionEndpointUri,
                                        SSLSocketFactory socketFactory,
@@ -83,7 +85,8 @@ public class OAuthIntrospectionValidator implements TokenValidator {
                                        String audience,
                                        String customClaimCheck,
                                        int connectTimeoutSeconds,
-                                       int readTimeoutSeconds) {
+                                       int readTimeoutSeconds,
+                                       String introspectionEndpointParam) {
 
         if (introspectionEndpointUri == null) {
             throw new IllegalArgumentException("introspectionEndpointUri == null");
@@ -134,6 +137,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
 
         this.connectTimeoutSeconds = connectTimeoutSeconds;
         this.readTimeoutSeconds = readTimeoutSeconds;
+        this.introspectionEndpointParam = introspectionEndpointParam;
 
         if (log.isDebugEnabled()) {
             log.debug("Configured OAuthIntrospectionValidator:\n    introspectionEndpointUri: " + introspectionURI
@@ -149,6 +153,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
                     + "\n    customClaimCheck: " + customClaimCheck
                     + "\n    connectTimeoutSeconds: " + connectTimeoutSeconds
                     + "\n    readTimeoutSeconds: " + readTimeoutSeconds
+                    + "\n    introspectionEndpointParam: " + introspectionEndpointParam
             );
         }
     }
@@ -171,7 +176,7 @@ public class OAuthIntrospectionValidator implements TokenValidator {
                 "Basic " + base64encode(clientId + ':' + clientSecret) :
                 null;
 
-        StringBuilder body = new StringBuilder("token=").append(token);
+        StringBuilder body = introspectionEndpointParam != null ? new StringBuilder(introspectionEndpointParam + "=").append(token) : new StringBuilder("token=").append(token);
 
         JsonNode response;
         try {

--- a/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
+++ b/oauth-common/src/test/java/io/strimzi/kafka/oauth/common/HttpUtilTimeoutTest.java
@@ -90,7 +90,7 @@ public class HttpUtilTimeoutTest {
             try {
                 OAuthIntrospectionValidator validator = new OAuthIntrospectionValidator("http://172.0.0.13:8079",
                         null, null, new PrincipalExtractor(), "http://172.0.0.13/", null, "Bearer",
-                        "kafka", "kafka-secret", null, null, timeout, timeout);
+                        "kafka", "kafka-secret", null, null, timeout, timeout, "token");
 
                 start = System.currentTimeMillis();
                 validator.validate("token");

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/JaasServerOauthValidatorCallbackHandler.java
@@ -308,6 +308,7 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
         } else {
 
             String introspectionEndpoint = config.getValue(ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_URI);
+            String introspectionEndpointParam = config.getValue(ServerConfig.OAUTH_INTROSPECTION_ENDPOINT_PARAM);
             String userInfoEndpoint = config.getValue(ServerConfig.OAUTH_USERINFO_ENDPOINT_URI);
             String validTokenType = config.getValue(ServerConfig.OAUTH_VALID_TOKEN_TYPE);
 
@@ -329,7 +330,8 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                     clientId,
                     clientSecret,
                     connectTimeout,
-                    readTimeout);
+                    readTimeout,
+                    introspectionEndpointParam);
 
             factory = () -> new OAuthIntrospectionValidator(
                     introspectionEndpoint,
@@ -344,7 +346,8 @@ public class JaasServerOauthValidatorCallbackHandler implements AuthenticateCall
                     audience,
                     customClaimCheck,
                     connectTimeout,
-                    readTimeout);
+                    readTimeout,
+                    introspectionEndpointParam);
         }
 
         validator = Services.getInstance().getValidators().get(vkey, factory);

--- a/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
+++ b/oauth-server/src/main/java/io/strimzi/kafka/oauth/server/ServerConfig.java
@@ -16,6 +16,7 @@ public class ServerConfig extends Config {
     public static final String OAUTH_JWKS_REFRESH_MIN_PAUSE_SECONDS = "oauth.jwks.refresh.min.pause.seconds";
     public static final String OAUTH_VALID_ISSUER_URI = "oauth.valid.issuer.uri";
     public static final String OAUTH_INTROSPECTION_ENDPOINT_URI = "oauth.introspection.endpoint.uri";
+    public static final String OAUTH_INTROSPECTION_ENDPOINT_PARAM = "oauth.introspection.endpoint.param";
     public static final String OAUTH_USERINFO_ENDPOINT_URI = "oauth.userinfo.endpoint.uri";
     public static final String OAUTH_CHECK_ACCESS_TOKEN_TYPE = "oauth.check.access.token.type";
     public static final String OAUTH_CHECK_ISSUER = "oauth.check.issuer";


### PR DESCRIPTION
They are using hardcode parameter(token=) for oauth introspection endpoint, but some people want to use some other parameter name such as atoken, btoken etc.
We configured enable to use dynamic oauth introspection endpoint parameter.